### PR TITLE
Fix definitions for CCapture onProgress and min/max Array functions

### DIFF
--- a/src/babyplots.d.ts
+++ b/src/babyplots.d.ts
@@ -104,12 +104,8 @@ export declare class CustomLoadingScreen implements ILoadingScreen {
     displayLoadingUI(): void;
     hideLoadingUI(): void;
 }
-declare global {
-    interface Array<T> {
-        min(): number;
-        max(): number;
-    }
-}
+export declare function getArrayMin(arr: Array<number | string>): number;
+export declare function getArrayMax(arr: Array<number | string>): number;
 export declare function matrixMax(matrix: number[][]): number;
 export declare function matrixMin(matrix: number[][]): number;
 export declare function getUniqueVals(source: string[]): string[];
@@ -199,6 +195,8 @@ export declare class Plots {
     addImgStack(values: number[], indices: number[], attributes: {
         dim: number[];
     }, options: {}): Plots;
+    private _parseOptions;
+    private _getColorsAndLegend;
     addPlot(coordinates: number[][], plotType: string, colorBy: string, colorVar: string[] | number[], options?: {}): Plots;
     addMeshObject(meshString: string, options: {}): Plots;
     addMeshStream(rootUrl: string, filePrefix: string, fileSuffix: string, fileIteratorStart: number, fileIteratorEnd: number, frameDelay: number, options: {}): Plots;
@@ -206,10 +204,12 @@ export declare class Plots {
     private _drawStandaloneShapeLegend;
     private _createPlotLegend;
     private _createShapeLegend;
+    private: any;
     doRender(): Plots;
     resize(width?: number, height?: number): Plots;
     thumbnail(size: number, saveCallback: (data: string) => void): Plots;
     dispose(): void;
     removePlot(index: number): Plots;
     addLabels(labelList: [[number, number, number, string, string?, number?]]): Plots;
+    update(index: number, coordinates: number[][], colorBy: string, colorVar: string[] | number[], options?: {}): void;
 }

--- a/src/babyplots.d.ts
+++ b/src/babyplots.d.ts
@@ -195,8 +195,6 @@ export declare class Plots {
     addImgStack(values: number[], indices: number[], attributes: {
         dim: number[];
     }, options: {}): Plots;
-    private _parseOptions;
-    private _getColorsAndLegend;
     addPlot(coordinates: number[][], plotType: string, colorBy: string, colorVar: string[] | number[], options?: {}): Plots;
     addMeshObject(meshString: string, options: {}): Plots;
     addMeshStream(rootUrl: string, filePrefix: string, fileSuffix: string, fileIteratorStart: number, fileIteratorEnd: number, frameDelay: number, options: {}): Plots;
@@ -204,12 +202,10 @@ export declare class Plots {
     private _drawStandaloneShapeLegend;
     private _createPlotLegend;
     private _createShapeLegend;
-    private: any;
     doRender(): Plots;
     resize(width?: number, height?: number): Plots;
     thumbnail(size: number, saveCallback: (data: string) => void): Plots;
     dispose(): void;
     removePlot(index: number): Plots;
     addLabels(labelList: [[number, number, number, string, string?, number?]]): Plots;
-    update(index: number, coordinates: number[][], colorBy: string, colorVar: string[] | number[], options?: {}): void;
 }

--- a/src/babyplots.ts
+++ b/src/babyplots.ts
@@ -133,14 +133,7 @@ interface CustomCCaptureSettings extends CCapture.Settings {
   onProgress: (pct: any) => void;
 }
 
-declare global {
-    interface Array<T> {
-        min(): number;
-        max(): number;
-    }
-}
-
-Array.prototype.min = function (): number {
+export function getArrayMin(arr: Array<number | string>): number {
     if (this.length > 65536) {
         let r = this[0];
         this.forEach(function (v: number, _i: any, _a: any) { if (v < r) r = v; });
@@ -148,9 +141,10 @@ Array.prototype.min = function (): number {
     } else {
         return Math.min.apply(null, this);
     }
+
 }
 
-Array.prototype.max = function (): number {
+export function getArrayMax(arr: Array<number | string>): number {
     if (this.length > 65536) {
         let r = this[0];
         this.forEach(function (v: number, _i: any, _a: any) { if (v > r) r = v; });
@@ -161,14 +155,14 @@ Array.prototype.max = function (): number {
 }
 
 export function matrixMax(matrix: number[][]): number {
-    let maxRow = matrix.map(function (row) { return row.max(); });
-    let max = maxRow.max();
+    let maxRow = matrix.map(function (row) { return getArrayMax(row); });
+    let max = getArrayMax(maxRow);
     return max
 }
 
 export function matrixMin(matrix: number[][]): number {
-    let minRow = matrix.map(function (row) { return row.min(); });
-    let min = minRow.min();
+    let minRow = matrix.map(function (row) { return getArrayMin(row); });
+    let min = getArrayMin(minRow);
     return min
 }
 
@@ -1624,8 +1618,8 @@ export class Plots {
                 break;
             case "values":
                 // color by a continuous variable
-                let min = colorVar.min();
-                let max = colorVar.max();
+                let min = getArrayMin(colorVar);
+                let max = getArrayMax(colorVar);
                 // Oranges is default color scale for continuous variable coloring
                 let colorfunc = chroma.scale(chroma.brewer.Oranges).mode('lch');
                 // check if color scale should be custom

--- a/src/babyplots.ts
+++ b/src/babyplots.ts
@@ -129,6 +129,10 @@ export class CustomLoadingScreen implements ILoadingScreen {
     }
 }
 
+interface CustomCCaptureSettings extends CCapture.Settings {
+  onProgress: (pct: any) => void;
+}
+
 declare global {
     interface Array<T> {
         min(): number;
@@ -1182,7 +1186,7 @@ export class Plots {
                     display: false,
                     quality: this._recordingQuality,
                     workersPath: worker
-                });
+                } as CustomCCaptureSettings);
                 // create capturer, enable turning
                 this._capturer.start();
                 this._origRotationRate = this.rotationRate;

--- a/src/babyplots.ts
+++ b/src/babyplots.ts
@@ -134,23 +134,23 @@ interface CustomCCaptureSettings extends CCapture.Settings {
 }
 
 export function getArrayMin(arr: Array<number | string>): number {
-    if (this.length > 65536) {
+    if (arr.length > 65536) {
         let r = this[0];
-        this.forEach(function (v: number, _i: any, _a: any) { if (v < r) r = v; });
+        arr.forEach(function (v: number, _i: any, _a: any) { if (v < r) r = v; });
         return r;
     } else {
-        return Math.min.apply(null, this);
+        return Math.min.apply(null, arr);
     }
 
 }
 
 export function getArrayMax(arr: Array<number | string>): number {
-    if (this.length > 65536) {
+    if (arr.length > 65536) {
         let r = this[0];
-        this.forEach(function (v: number, _i: any, _a: any) { if (v > r) r = v; });
+        arr.forEach(function (v: number, _i: any, _a: any) { if (v > r) r = v; });
         return r;
     } else {
-        return Math.max.apply(null, this);
+        return Math.max.apply(null, arr);
     }
 }
 

--- a/src/plotTypes/ImgStack.ts
+++ b/src/plotTypes/ImgStack.ts
@@ -22,6 +22,7 @@ import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Color3 } from "@babylonjs/core/Maths/math";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { getArrayMin } from "../babyplots";
 import { LegendData } from "../utils/LegendData";
 import { Plot } from "../utils/Plot";
 import chroma from "chroma-js";
@@ -111,7 +112,7 @@ export class ImgStack extends Plot {
             channelColorRGB[2] = channelColorRGB[2] / 255;
             if (this._intensityMode === "alpha") {
                 let alphaLevels = 10;
-                let minIntensity = channelIntensities.min();
+                let minIntensity = getArrayMin(channelIntensities);
                 let alphaPositions: number[][] = [];
                 let alphaColors: number[][] = [];
                 let alphaIntensities: number[] = [];


### PR DESCRIPTION
- Fixing build error on missing CCapture onProgress type:
```
src/babyplots.ts:1177:21 - error TS2345: Argument of type '{ format: "gif"; framerate: number; onProgress: (pct: any) => void; verbose: false; display: false; quality: number; workersPath: string; }' is not assi
gnable to parameter of type 'Settings'.                                                                  
  Object literal may only specify known properties, and 'onProgress' does not exist in type 'Settings'.  
                                                                                                         
1177                     onProgress: (pct) => {                                                          
1178                         let loadingProgress = document.getElementById("GIFloadingProgress_" + this._uniqID);
1179                         loadingProgress.style.width = (pct * 100).toString() + "%";                 
1180                     },                                                                                                                                                                                        
```

- Changing min and max functions defined in the Array prototype as this can lead to conflicts when using babyplots together with other JS modules.

